### PR TITLE
ISSUE-14 Fix layout flaws in the German version

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -249,13 +249,15 @@ main ul li + li {
   padding-top: 0.75rem;
 }
 
-nav[aria-label="page"] {
+nav[aria-label="page"],
+nav[aria-label="Seite"] {
   text-align: right;
   background: url(/images/line.svg) repeat-x center;
   font-size: 0.8rem;
 }
 
-nav[aria-label="page"] ul {
+nav[aria-label="page"] ul,
+nav[aria-label="Seite"] ul {
   padding: 0.5rem 1rem 0.5rem 0.5rem;
   display: inline-block;
   text-transform: uppercase;

--- a/css/style.css
+++ b/css/style.css
@@ -119,6 +119,10 @@ h1 {
   margin-top: 1rem;
 }
 
+.title-and-illustration h1 {
+  width: 60%;
+}
+
 .title-and-illustration img {
   width: 40%;
   height: auto;
@@ -145,6 +149,10 @@ h1 {
 }
 
 @media (max-width: 370px) {
+  .title-and-illustration h1 {
+    width: 63%;
+  }
+
   .title-and-illustration img {
     width: 37%;
     margin-top: 1.5rem;

--- a/de/index.html
+++ b/de/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link
-    href="https://fonts.googleapis.com/css?family=Miriam+Libre:700&text=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz%26"
+    href="https://fonts.googleapis.com/css?family=Miriam+Libre:700&text=ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜabcdefghijklmnopqrstuvwxyzäöüß%26"
     rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Asap:400,400i&subset=latin" rel="stylesheet">
   <link rel="canonical" href="https://inclusivedesignprinciples.info/" />
@@ -26,7 +26,7 @@
     <nav aria-label="Seite">
       <ul>
         <li><a href="#introduction">Einführung</a></li>
-        <li><a href="#principles">Die Designprinzipien</a></li>
+        <li><a href="#principles">Die Design&shy;prinzipien</a></li>
       </ul>
     </nav>
 
@@ -46,7 +46,7 @@
     <div>
       <div class="title-and-illustration">
         <h1>
-          Inklusive Designprinzipien
+          Inklusive Design&shy;prinzipien
         </h1>
         <img src="/images/balloons_opt.svg"
           alt="Drei Heißluftballons hängen zusammen an einem ruhigen, sonnigen Himmel" />
@@ -226,7 +226,7 @@
         <p><em>Stelle sicher, dass die Menschen die Kontrolle haben. Menschen sollten in der Lage sein, auf die von
             ihnen bevorzugte Weise auf Inhalte zuzugreifen und mit ihnen zu interagieren.</em></p>
         <h4>Gesamte Beschreibung</h4>
-        <p>Unterdrücke oder deaktiviere nicht die Möglichkeit, Standard Browser- und Plattformeinstellungen wie
+        <p>Unterdrücke oder deaktiviere nicht die Möglichkeit, Standard Browser- und Plattform&shy;einstellungen wie
           Ausrichtung, Schriftgröße, Zoom und Kontrast zu ändern. Vermeide außerdem Inhaltsänderungen, die nicht von
           Benutzer*innen initiiert wurden, es sei denn, es gibt eine Möglichkeit, dies zu kontrollieren.</p>
         <h4>Beispiele</h4>
@@ -251,7 +251,7 @@
     </div>
     <div class="principle-container">
       <div class="intro">
-        <h3 id="offer-choice">Biete Wahlmöglichkeiten
+        <h3 id="offer-choice">Biete Wahl&shy;möglichkeiten
         </h3>
         <button data-expands="offer-choice-content" aria-label="Abschnitt öffnen"
           aria-describedby="biete-wahlmöglichkeiten" hidden>
@@ -269,13 +269,12 @@
             solchen, die komplex oder nicht standardisiert sind.</em></p>
         <h4>Gesamte Beschreibung</h4>
         <p>Es gibt oft mehr als eine Möglichkeit, eine Aufgabe zu erledigen. Man kann nicht davon ausgehen, welcher Weg
-          bevorzugt wird. Indem du Alternativen für das Layout und die Aufgabenerledigung bereitstellst, bietest du
-          Menschen Auswahlmöglichkeiten, die zu ihnen und ihren jeweiligen Umständen passen.</p>
+          bevorzugt wird. Indem du Alternativen für das Layout und die Aufgaben&shy;erledigung bereitstellst, bietest du Menschen Auswahl&shy;möglichkeiten, die zu ihnen und ihren jeweiligen Umständen passen.</p>
         <h4>Beispiele</h4>
         <ul class="examples">
           <li><strong>Mehrere Möglichkeiten, eine Aktion abzuschließen:</strong> Wenn möglich gebe mehrere Möglichkeiten
             zum Abschließen einer Aktion. Auf Mobilgeräten kann das Wischen zum Löschen eines Elements zusammen mit
-            einer Bearbeitungsschaltfläche unterstützt werden, mit der Elemente ausgewählt und dann gelöscht werden
+            einer Bearbeitungs&shy;schaltfläche unterstützt werden, mit der Elemente ausgewählt und dann gelöscht werden
             können. Ein Beispiel hierfür ist in iOS-Mail.</li>
           <li><strong>Layout:</strong> Ziehe bei langen Inhaltslisten in Betracht, eine Raster- oder Listenlayoutoption
             anzubieten. Dies unterstützt Personen, die größere Bilder auf dem Bildschirm oder kleinere Zeilen wünschen.
@@ -365,7 +364,7 @@
         <p>Funktionen sollten die Benutzbarkeit aufwerten, indem sie effiziente und vielfältige Möglichkeiten bieten,
           Inhalte zu finden und mit ihnen zu interagieren. Berücksichtige Gerätefunktionen wie Sprach-,
           Geolokalisierungs-, Kamera- und Vibrations-APIs und wie die Integration mit angeschlossenen Geräten oder einem
-          zweiten Bildschirm Wahlmöglichkeiten bieten könnte.</p>
+          zweiten Bildschirm Wahl&shy;möglichkeiten bieten könnte.</p>
         <h4>Beispiele</h4>
         <ul class="examples">
           <li><strong>Integration mit angeschlossenen Geräten oder zweitem Bildschirm:</strong> Die Verwendung von
@@ -375,7 +374,7 @@
             Plattformfunktionen. Die Vibrations-API macht Benachrichtigungen für gehörlose und schwerhörige Menschen
             besser nutzbar, während die Geolokalisierungs-API es Menschen mit Mobilitätseinschränkungen erleichtert,
             standortbasierte Dienste zu nutzen.</li>
-          <li><strong>Erleichtere die Aufgabenerledigung:</strong> Füge den Eingabefeldern eine Schaltfläche „Passwort
+          <li><strong>Erleichtere die Aufgaben&shy;erledigung:</strong> Füge den Eingabefeldern eine Schaltfläche „Passwort
             anzeigen“ hinzu, damit Menschen überprüfen können, ob sie den Text richtig eingegeben haben, oder füge eine
             Touch-Identifizierung für passwortgeschützte Bereiche hinzu.</li>
         </ul>

--- a/de/index.html
+++ b/de/index.html
@@ -2,7 +2,6 @@
 <html lang="de">
 
 <head>
-
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -24,7 +23,7 @@
 
 <body>
   <header>
-    <nav aria-label="seite">
+    <nav aria-label="Seite">
       <ul>
         <li><a href="#introduction">Einführung</a></li>
         <li><a href="#principles">Die Designprinzipien</a></li>


### PR DESCRIPTION
Fixes #14

- Limited the `<h1>` width to prevent text and image overlapping
- Updated the in-page `nav` CSS selector to add the styling to the German variant
- Added missing umlauts to the Google font params
- Allowed long words to be broken with a soft hyphen